### PR TITLE
fix: openEditor return undefined will get a destructure error

### DIFF
--- a/lib/openEditor.js
+++ b/lib/openEditor.js
@@ -96,7 +96,7 @@ module.exports = async function openEditor({
     });
 
     setTimeout(() => {
-      resolve()
+      resolve({})
     }, 2500);
   });
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13557235/62517321-c5b3b600-b859-11e9-9dc7-a7e83036313a.png)


![image](https://user-images.githubusercontent.com/13557235/62517379-e2e88480-b859-11e9-8419-141313eb933b.png)
